### PR TITLE
Add STL export and MeshExporter dispatch; expose `--format` in CLI and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A modern C++ toolkit for generating hexahedral finite element meshes from molecu
 - **Bounding Box Calculation** - Compute 3D molecular bounding boxes with padding
 - **Uniform Voxelization** - Tessellate space into regular cubic voxels
 - **Dual Mesh Generation** - Create meshes from both occupied and empty voxels
-- **GiD Export** - Export to industry-standard GiD mesh format (. msh)
+- **Mesh Export (GiD/STL)** - Export volumetric meshes to GiD (.msh) or boundary surface meshes to STL (.stl)
 - **Molecule Filtering** - Filter by protein, nucleic acids, water, ions, etc.
 
 ### Advanced Features
@@ -169,6 +169,7 @@ done
 | `-v, --voxel-size VALUE` | Voxel edge length (Å) | 1.0 |
 | `-p, --padding VALUE` | Bounding box padding (Å) | 2.0 |
 | `-o, --output BASENAME` | Output file basename | mesh |
+| `-f, --format FORMAT` | Output format (`gid` or `stl`) | gid |
 | `--occupied BOOL` | Generate occupied mesh | true |
 | `--empty BOOL` | Generate empty mesh | true |
 | `--filter TYPE` | Molecule filter | none |
@@ -200,6 +201,7 @@ padding = 2.0
 
 [output]
 basename = high_res_mesh
+format = gid
 generate_occupied = true
 generate_empty = true
 
@@ -477,7 +479,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Roadmap
 
-- [ ] VTK export format
+- [x] STL export format (`--format stl`)
 - [ ] Python bindings (pybind11)
 - [ ] Adaptive mesh refinement
 - [ ] Surface mesh extraction

--- a/biomesh.sh
+++ b/biomesh.sh
@@ -25,7 +25,7 @@ Options:
   -v, --voxel-size VALUE     Voxel size in Angstroms (default: 1.0)
       --inflate-factor VALUE Radius scale factor for atom vdW radii (default: 1.0)
   -p, --padding VALUE        Bounding box padding in Angstroms (default: 2.0)
-  -f, --format FORMAT        Output format (vtk|gid|json|txt) (default: gid)
+  -f, --format FORMAT        Output format (gid|stl) (default: gid)
       --filter TYPE          Filter type (none|all|protein-only|no-water|custom)
       --occupied BOOL        Generate occupied mesh (true|false) (default: true)
       --empty BOOL           Generate empty mesh (true|false) (default: true)
@@ -122,6 +122,7 @@ padding = 2.0
 # Will generate: <basename>_occupied.msh and <basename>_empty.msh
 basename = mesh
 format = gid
+# Supported formats: gid, stl
 
 # Control which meshes to generate
 generate_occupied = true
@@ -143,7 +144,7 @@ allowed_filter() {
 
 allowed_format() {
     case "$1" in
-    vtk|gid|json|txt) return 0 ;;
+    gid|stl) return 0 ;;
     *) return 1 ;;
     esac
 }
@@ -218,9 +219,7 @@ EOF
 get_file_extension() {
     case "$output_format" in
     gid) echo "msh" ;;
-    vtk) echo "vtk" ;;
-    json) echo "json" ;;
-    txt) echo "txt" ;;
+    stl) echo "stl" ;;
     *) echo "msh" ;;  # Default to msh
     esac
 }
@@ -258,9 +257,9 @@ run_dual_mesh_generation() {
             
             log ""
             log "═══ Generating Occupied Mesh ═══"
-            logv "Running: $OCCUPIED_CMD $input_file $voxel_size $occupied_output $padding $inflate_factor"
+            logv "Running: $OCCUPIED_CMD $input_file $voxel_size $occupied_output $padding $inflate_factor $output_format"
             
-            if "$OCCUPIED_CMD" "$input_file" "$voxel_size" "$occupied_output" "$padding" "$inflate_factor"; then
+            if "$OCCUPIED_CMD" "$input_file" "$voxel_size" "$occupied_output" "$padding" "$inflate_factor" "$output_format"; then
                 log "✓ Occupied mesh generated: $occupied_output"
                 write_summary "occupied" "$input_file" "$occupied_output"
                 generated_files+=("$occupied_output")
@@ -286,9 +285,9 @@ run_dual_mesh_generation() {
             
             log ""
             log "═══ Generating Empty Mesh ═══"
-            logv "Running: $EMPTY_CMD $input_file $voxel_size $empty_output $padding $inflate_factor"
+            logv "Running: $EMPTY_CMD $input_file $voxel_size $empty_output $padding $inflate_factor $output_format"
             
-            if "$EMPTY_CMD" "$input_file" "$voxel_size" "$empty_output" "$padding" "$inflate_factor"; then
+            if "$EMPTY_CMD" "$input_file" "$voxel_size" "$empty_output" "$padding" "$inflate_factor" "$output_format"; then
                 log "✓ Empty mesh generated: $empty_output"
                 write_summary "empty" "$input_file" "$empty_output"
                 generated_files+=("$empty_output")

--- a/config/default.conf
+++ b/config/default.conf
@@ -21,6 +21,7 @@ padding = 2.0
 # Will generate: <basename>_occupied.msh and <basename>_empty.msh
 basename = mesh
 format = gid
+# Supported formats: gid, stl
 
 # Control which meshes to generate
 generate_occupied = true

--- a/examples/empty_voxel_to_gid.cpp
+++ b/examples/empty_voxel_to_gid.cpp
@@ -1,5 +1,5 @@
 #include "biomesh/EmptyVoxelMeshGenerator.hpp"
-#include "biomesh/GiDExporter.hpp"
+#include "biomesh/MeshExporter.hpp"
 #include "biomesh/VoxelGrid.hpp"
 #include "biomesh/PDBParser.hpp"
 #include "biomesh/AtomBuilder.hpp"
@@ -10,21 +10,22 @@
 using namespace biomesh;
 
 void printUsage(const char* programName) {
-    std::cout << "\nUsage: " << programName << " <pdb_file> <voxel_size> <output_file> [padding] [inflate_factor]\n\n";
+    std::cout << "\nUsage: " << programName << " <pdb_file> <voxel_size> <output_file> [padding] [inflate_factor] [format]\n\n";
     std::cout << "Arguments:\n";
     std::cout << "  pdb_file     : Path to input PDB file\n";
     std::cout << "  voxel_size   : Edge length of voxels in Angstroms (e.g., 1.0)\n";
-    std::cout << "  output_file  : Output GiD mesh file path (e.g., empty_mesh.msh)\n";
+    std::cout << "  output_file  : Output mesh file path (e.g., empty_mesh.msh or empty_mesh.stl)\n";
     std::cout << "  padding      : Optional padding around bounding box in Angstroms (default: 2.0)\n";
-    std::cout << "  inflate_factor : Optional radius scale factor (default: 1.0)\n\n";
+    std::cout << "  inflate_factor : Optional radius scale factor (default: 1.0)\n";
+    std::cout << "  format       : Optional export format gid|stl (default: gid)\n\n";
     std::cout << "Example:\n";
-    std::cout << "  " << programName << " protein.pdb 1.0 empty_mesh.msh 2.0 1.0\n\n";
+    std::cout << "  " << programName << " protein.pdb 1.0 empty_mesh.stl 2.0 1.0 stl\n\n";
     std::cout << "Note: Empty voxel meshes can be very large (typically 95-99% of total voxels).\n";
     std::cout << "      Use larger voxel sizes for initial testing.\n\n";
 }
 
 int main(int argc, char* argv[]) {
-    std::cout << "BioMesh - Empty Voxel Mesh Generator with GiD Export\n";
+    std::cout << "BioMesh - Empty Voxel Mesh Generator with Mesh Export\n";
     std::cout << "======================================================\n\n";
     
     // Check arguments
@@ -39,6 +40,7 @@ int main(int argc, char* argv[]) {
     std::string outputFile = argv[3];
     double padding = 2.0; // Default padding
     double inflateFactor = 1.0; // Default atom radius scale
+    std::string outputFormat = "gid"; // Default format
     
     // Parse voxel size
     try {
@@ -78,6 +80,11 @@ int main(int argc, char* argv[]) {
             std::cerr << "Error: Invalid inflate factor value: " << argv[5] << "\n";
             return 1;
         }
+    }
+    
+    // Parse optional output format
+    if (argc > 6) {
+        outputFormat = argv[6];
     }
     
     try {
@@ -127,14 +134,14 @@ int main(int argc, char* argv[]) {
                       << " elements). File may be large.\n\n";
         }
         
-        // Step 5: Export to GiD format
-        std::cout << "Exporting to GiD format: " << outputFile << "\n";
-        bool success = GiDExporter::exportToGiD(mesh, outputFile);
+        // Step 5: Export to selected format
+        std::cout << "Exporting to format [" << outputFormat << "]: " << outputFile << "\n";
+        bool success = MeshExporter::exportMesh(mesh, outputFile, outputFormat);
         
         if (success) {
             std::cout << "  Export successful!\n";
             std::cout << "\nMesh file written to: " << outputFile << "\n";
-            std::cout << "You can now open this file in GiD or any compatible FEM/CFD software.\n";
+            std::cout << "You can now open this file in tools compatible with the selected output format.\n";
             return 0;
         } else {
             std::cerr << "  Export failed!\n";

--- a/examples/occupied_voxel_to_gid.cpp
+++ b/examples/occupied_voxel_to_gid.cpp
@@ -1,5 +1,5 @@
 #include "biomesh/VoxelMeshGenerator.hpp"
-#include "biomesh/GiDExporter.hpp"
+#include "biomesh/MeshExporter.hpp"
 #include "biomesh/VoxelGrid.hpp"
 #include "biomesh/PDBParser.hpp"
 #include "biomesh/AtomBuilder.hpp"
@@ -10,21 +10,22 @@
 using namespace biomesh;
 
 void printUsage(const char* programName) {
-    std::cout << "\nUsage: " << programName << " <pdb_file> <voxel_size> <output_file> [padding] [inflate_factor]\n\n";
+    std::cout << "\nUsage: " << programName << " <pdb_file> <voxel_size> <output_file> [padding] [inflate_factor] [format]\n\n";
     std::cout << "Arguments:\n";
     std::cout << "  pdb_file     : Path to input PDB file\n";
     std::cout << "  voxel_size   : Edge length of voxels in Angstroms (e.g., 1.0)\n";
-    std::cout << "  output_file  : Output GiD mesh file path (e.g., occupied_mesh.msh)\n";
+    std::cout << "  output_file  : Output mesh file path (e.g., occupied_mesh.msh or occupied_mesh.stl)\n";
     std::cout << "  padding      : Optional padding around bounding box in Angstroms (default: 2.0)\n";
-    std::cout << "  inflate_factor : Optional radius scale factor (default: 1.0)\n\n";
+    std::cout << "  inflate_factor : Optional radius scale factor (default: 1.0)\n";
+    std::cout << "  format       : Optional export format gid|stl (default: gid)\n\n";
     std::cout << "Example:\n";
-    std::cout << "  " << programName << " protein.pdb 1.0 occupied_mesh.msh 2.0 1.0\n\n";
+    std::cout << "  " << programName << " protein.pdb 1.0 occupied_mesh.msh 2.0 1.0 gid\n\n";
     std::cout << "Note: Occupied voxel meshes represent the molecule volume.\n";
     std::cout << "      Use larger voxel sizes for initial testing.\n\n";
 }
 
 int main(int argc, char* argv[]) {
-    std::cout << "BioMesh - Occupied Voxel Mesh Generator with GiD Export\n";
+    std::cout << "BioMesh - Occupied Voxel Mesh Generator with Mesh Export\n";
     std::cout << "========================================================\n\n";
     
     // Check arguments
@@ -39,6 +40,7 @@ int main(int argc, char* argv[]) {
     std::string outputFile = argv[3];
     double padding = 2.0; // Default padding
     double inflateFactor = 1.0; // Default atom radius scale
+    std::string outputFormat = "gid"; // Default format
     
     // Parse voxel size
     try {
@@ -78,6 +80,11 @@ int main(int argc, char* argv[]) {
             std::cerr << "Error: Invalid inflate factor value: " << argv[5] << "\n";
             return 1;
         }
+    }
+    
+    // Parse optional output format
+    if (argc > 6) {
+        outputFormat = argv[6];
     }
     
     try {
@@ -130,14 +137,14 @@ int main(int argc, char* argv[]) {
                       << " elements). File may be large.\n\n";
         }
         
-        // Step 5: Export to GiD format
-        std::cout << "Exporting to GiD format: " << outputFile << "\n";
-        bool success = GiDExporter::exportToGiD(mesh, outputFile);
+        // Step 5: Export to selected format
+        std::cout << "Exporting to format [" << outputFormat << "]: " << outputFile << "\n";
+        bool success = MeshExporter::exportMesh(mesh, outputFile, outputFormat);
         
         if (success) {
             std::cout << "  Export successful!\n";
             std::cout << "\nMesh file written to: " << outputFile << "\n";
-            std::cout << "You can now open this file in GiD or any compatible FEM/CFD software.\n";
+            std::cout << "You can now open this file in tools compatible with the selected output format.\n";
             return 0;
         } else {
             std::cerr << "  Export failed!\n";

--- a/include/biomesh/MeshExporter.hpp
+++ b/include/biomesh/MeshExporter.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "biomesh/HexMesh.hpp"
+#include <string>
+
+namespace biomesh {
+
+class MeshExporter {
+public:
+    /**
+     * @brief Export mesh to the requested format.
+     * @param mesh Mesh data.
+     * @param filename Output path.
+     * @param format Output format (gid|stl).
+     * @return true on success, false on error.
+     */
+    static bool exportMesh(const HexMesh& mesh, const std::string& filename, const std::string& format);
+};
+
+} // namespace biomesh

--- a/include/biomesh/STLExporter.hpp
+++ b/include/biomesh/STLExporter.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "biomesh/HexMesh.hpp"
+#include <string>
+
+namespace biomesh {
+
+/**
+ * @brief ASCII STL exporter for hexahedral meshes.
+ *
+ * Exports only the boundary surface as triangulated facets.
+ */
+class STLExporter {
+public:
+    /**
+     * @brief Export hexahedral mesh boundary to ASCII STL format.
+     * @param mesh The hexahedral mesh to export.
+     * @param filename Output file path (should end with .stl).
+     * @return true if export was successful, false otherwise.
+     */
+    static bool exportToSTL(const HexMesh& mesh, const std::string& filename);
+};
+
+} // namespace biomesh

--- a/src/MeshExporter.cpp
+++ b/src/MeshExporter.cpp
@@ -1,0 +1,26 @@
+#include "biomesh/MeshExporter.hpp"
+#include "biomesh/GiDExporter.hpp"
+#include "biomesh/STLExporter.hpp"
+#include <algorithm>
+#include <cctype>
+#include <iostream>
+
+namespace biomesh {
+
+bool MeshExporter::exportMesh(const HexMesh& mesh, const std::string& filename, const std::string& format) {
+    std::string normalized = format;
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    if (normalized == "gid") {
+        return GiDExporter::exportToGiD(mesh, filename);
+    }
+    if (normalized == "stl") {
+        return STLExporter::exportToSTL(mesh, filename);
+    }
+
+    std::cerr << "Error: Unsupported export format: " << format << "\n";
+    return false;
+}
+
+} // namespace biomesh

--- a/src/STLExporter.cpp
+++ b/src/STLExporter.cpp
@@ -1,0 +1,149 @@
+#include "biomesh/STLExporter.hpp"
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+namespace biomesh {
+namespace {
+
+struct Vec3 {
+    double x;
+    double y;
+    double z;
+};
+
+Vec3 sub(const Point3D& a, const Point3D& b) {
+    return {a.x - b.x, a.y - b.y, a.z - b.z};
+}
+
+Vec3 cross(const Vec3& a, const Vec3& b) {
+    return {
+        a.y * b.z - a.z * b.y,
+        a.z * b.x - a.x * b.z,
+        a.x * b.y - a.y * b.x,
+    };
+}
+
+void normalize(Vec3& v) {
+    const double n = std::sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+    if (n > 1e-16) {
+        v.x /= n;
+        v.y /= n;
+        v.z /= n;
+    } else {
+        v = {0.0, 0.0, 0.0};
+    }
+}
+
+struct FaceKey {
+    std::array<int, 4> nodes;
+
+    bool operator==(const FaceKey& other) const {
+        return nodes == other.nodes;
+    }
+};
+
+struct FaceKeyHash {
+    std::size_t operator()(const FaceKey& key) const {
+        std::size_t h = 0;
+        for (int n : key.nodes) {
+            h ^= std::hash<int>{}(n) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        }
+        return h;
+    }
+};
+
+FaceKey makeCanonicalFaceKey(const std::array<int, 4>& face) {
+    std::array<int, 4> sorted = face;
+    std::sort(sorted.begin(), sorted.end());
+    return {sorted};
+}
+
+} // namespace
+
+bool STLExporter::exportToSTL(const HexMesh& mesh, const std::string& filename) {
+    if (mesh.nodes.empty() || mesh.elements.empty()) {
+        std::cerr << "Error: Cannot export empty mesh to STL format\n";
+        return false;
+    }
+
+    std::ofstream outFile(filename);
+    if (!outFile.is_open()) {
+        std::cerr << "Error: Could not open file for writing: " << filename << "\n";
+        return false;
+    }
+
+    static const std::array<std::array<int, 4>, 6> hexFaces = {{
+        {0, 1, 2, 3},
+        {4, 5, 6, 7},
+        {0, 1, 5, 4},
+        {1, 2, 6, 5},
+        {2, 3, 7, 6},
+        {3, 0, 4, 7},
+    }};
+
+    std::unordered_map<FaceKey, std::array<int, 4>, FaceKeyHash> boundaryFaces;
+
+    for (const auto& element : mesh.elements) {
+        for (const auto& localFace : hexFaces) {
+            std::array<int, 4> globalFace = {
+                element[localFace[0]],
+                element[localFace[1]],
+                element[localFace[2]],
+                element[localFace[3]],
+            };
+
+            FaceKey key = makeCanonicalFaceKey(globalFace);
+            auto it = boundaryFaces.find(key);
+            if (it == boundaryFaces.end()) {
+                boundaryFaces.emplace(key, globalFace);
+            } else {
+                boundaryFaces.erase(it);
+            }
+        }
+    }
+
+    outFile << "solid biomesh\n";
+    outFile << std::fixed << std::setprecision(6);
+
+    for (const auto& entry : boundaryFaces) {
+        const auto& quad = entry.second;
+
+        const Point3D& p0 = mesh.nodes[quad[0]];
+        const Point3D& p1 = mesh.nodes[quad[1]];
+        const Point3D& p2 = mesh.nodes[quad[2]];
+        const Point3D& p3 = mesh.nodes[quad[3]];
+
+        const std::array<std::array<const Point3D*, 3>, 2> tris = {{
+            {{&p0, &p1, &p2}},
+            {{&p0, &p2, &p3}},
+        }};
+
+        for (const auto& tri : tris) {
+            Vec3 u = sub(*tri[1], *tri[0]);
+            Vec3 v = sub(*tri[2], *tri[0]);
+            Vec3 n = cross(u, v);
+            normalize(n);
+
+            outFile << "  facet normal " << n.x << " " << n.y << " " << n.z << "\n";
+            outFile << "    outer loop\n";
+            outFile << "      vertex " << tri[0]->x << " " << tri[0]->y << " " << tri[0]->z << "\n";
+            outFile << "      vertex " << tri[1]->x << " " << tri[1]->y << " " << tri[1]->z << "\n";
+            outFile << "      vertex " << tri[2]->x << " " << tri[2]->y << " " << tri[2]->z << "\n";
+            outFile << "    endloop\n";
+            outFile << "  endfacet\n";
+        }
+    }
+
+    outFile << "endsolid biomesh\n";
+    outFile.close();
+
+    return true;
+}
+
+} // namespace biomesh

--- a/tests/test_exporters.cpp
+++ b/tests/test_exporters.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+#include "biomesh/HexMesh.hpp"
+#include "biomesh/GiDExporter.hpp"
+#include "biomesh/STLExporter.hpp"
+#include "biomesh/MeshExporter.hpp"
+#include <fstream>
+#include <cstdio>
+#include <string>
+#include <sstream>
+
+using namespace biomesh;
+
+namespace {
+
+HexMesh makeSingleHexMesh() {
+    HexMesh mesh;
+    mesh.nodes = {
+        {0.0, 0.0, 0.0},
+        {1.0, 0.0, 0.0},
+        {1.0, 1.0, 0.0},
+        {0.0, 1.0, 0.0},
+        {0.0, 0.0, 1.0},
+        {1.0, 0.0, 1.0},
+        {1.0, 1.0, 1.0},
+        {0.0, 1.0, 1.0},
+    };
+    mesh.elements.push_back({0, 1, 2, 3, 4, 5, 6, 7});
+    return mesh;
+}
+
+std::string readFile(const std::string& path) {
+    std::ifstream in(path);
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+int countOccurrences(const std::string& text, const std::string& needle) {
+    int count = 0;
+    std::string::size_type pos = 0;
+    while ((pos = text.find(needle, pos)) != std::string::npos) {
+        ++count;
+        pos += needle.size();
+    }
+    return count;
+}
+
+} // namespace
+
+TEST(ExporterTest, GiDExporterWritesExpectedSections) {
+    HexMesh mesh = makeSingleHexMesh();
+    const std::string file = "test_single_hex.msh";
+
+    ASSERT_TRUE(GiDExporter::exportToGiD(mesh, file));
+
+    std::string contents = readFile(file);
+    EXPECT_NE(contents.find("MESH dimension 3 ElemType Hexahedra Nnode 8"), std::string::npos);
+    EXPECT_NE(contents.find("Coordinates"), std::string::npos);
+    EXPECT_NE(contents.find("Elements"), std::string::npos);
+
+    std::remove(file.c_str());
+}
+
+TEST(ExporterTest, STLExporterWritesExpectedFacetCountForSingleHex) {
+    HexMesh mesh = makeSingleHexMesh();
+    const std::string file = "test_single_hex.stl";
+
+    ASSERT_TRUE(STLExporter::exportToSTL(mesh, file));
+
+    std::string contents = readFile(file);
+    EXPECT_NE(contents.find("solid biomesh"), std::string::npos);
+    EXPECT_EQ(countOccurrences(contents, "facet normal"), 12);
+
+    std::remove(file.c_str());
+}
+
+TEST(ExporterTest, MeshExporterDispatchesByFormatAndRejectsUnsupported) {
+    HexMesh mesh = makeSingleHexMesh();
+
+    const std::string gidFile = "dispatch_gid.msh";
+    const std::string stlFile = "dispatch_stl.stl";
+
+    EXPECT_TRUE(MeshExporter::exportMesh(mesh, gidFile, "gid"));
+    EXPECT_TRUE(MeshExporter::exportMesh(mesh, stlFile, "stl"));
+    EXPECT_TRUE(MeshExporter::exportMesh(mesh, gidFile, "GiD"));
+    EXPECT_TRUE(MeshExporter::exportMesh(mesh, stlFile, "STL"));
+    EXPECT_FALSE(MeshExporter::exportMesh(mesh, "bad.out", "json"));
+
+    std::remove(gidFile.c_str());
+    std::remove(stlFile.c_str());
+}


### PR DESCRIPTION
### Motivation
- Add support for exporting boundary surfaces to ASCII STL in addition to GiD to allow simpler surface workflows.
- Centralize export logic behind a single dispatcher so callers can request formats by name (`gid`/`stl`).
- Surface export requires changes to examples, CLI, and default configs so users can select output format.

### Description
- Added `MeshExporter` with `exportMesh(const HexMesh&, const std::string&, const std::string&)` to dispatch between `GiDExporter` and `STLExporter` implementations. 
- Implemented `STLExporter` (header and `src/STLExporter.cpp`) that extracts boundary quads from hexahedral elements and writes ASCII STL triangles. 
- Updated example programs (`examples/occupied_voxel_to_gid.cpp`, `examples/empty_voxel_to_gid.cpp`) to accept an optional `format` argument and use `MeshExporter::exportMesh`. 
- Updated CLI script `biomesh.sh`, README, and `config/default.conf` to add `--format`/`format` default (`gid`) and to pass the format through to mesh executables; restricted allowed formats to `gid|stl`. 
- Added unit tests `tests/test_exporters.cpp` covering GiD export content, STL facet counting for a single hexahedron, and `MeshExporter` dispatch/error handling. 

### Testing
- Built the project and ran the new exporter unit tests via the test runner for `tests/test_exporters.cpp`, and all tests passed. 
- Verified that `MeshExporter::exportMesh` returns `true` for `gid`/`stl` (case-insensitive) and `false` for unsupported formats in automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8913e52c08320b1ea4383f202c314)