### PR TITLE
Add unified `biomesh` preprocessing skeleton (Ticket 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ target_link_libraries(empty_voxel_to_gid biomesh_lib)
 add_executable(occupied_voxel_to_gid examples/occupied_voxel_to_gid.cpp)
 target_link_libraries(occupied_voxel_to_gid biomesh_lib)
 
+# Create unified biomesh executable (shared preprocessing skeleton)
+add_executable(biomesh examples/biomesh.cpp)
+target_link_libraries(biomesh biomesh_lib)
+
 # Create executable for filter demonstration
 add_executable(filter_demo examples/filter_demo.cpp)
 target_link_libraries(filter_demo biomesh_lib)

--- a/examples/biomesh.cpp
+++ b/examples/biomesh.cpp
@@ -1,0 +1,179 @@
+#include "biomesh/PDBParser.hpp"
+#include "biomesh/AtomBuilder.hpp"
+#include "biomesh/VoxelGrid.hpp"
+
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace biomesh;
+
+namespace {
+
+enum class MeshMode {
+    Occupied,
+    Empty,
+    Both
+};
+
+struct CliOptions {
+    std::string pdbFile;
+    double voxelSize = 0.0;
+    MeshMode meshMode = MeshMode::Occupied;
+    double padding = 2.0;
+    double inflateFactor = 1.0;
+    std::string outputFormat = "gid";
+    std::string output;
+    std::string occupiedOutput;
+    std::string emptyOutput;
+};
+
+void printUsage(const char* programName) {
+    std::cout << "Usage: " << programName << " <pdb_file> <voxel_size> [options]\n\n";
+    std::cout << "Required arguments:\n";
+    std::cout << "  pdb_file                         Path to input PDB file\n";
+    std::cout << "  voxel_size                       Positive voxel edge length in Angstroms\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --mesh <occupied|empty|both>     Mesh mode (default: occupied)\n";
+    std::cout << "  --padding <number>               Padding around bounds in Angstroms (default: 2.0)\n";
+    std::cout << "  --inflate-factor <number>        Atom radius scale factor (default: 1.0)\n";
+    std::cout << "  --format <gid|stl>               Mesh export format (default: gid)\n";
+    std::cout << "  --output <file>                  Required for occupied/empty modes\n";
+    std::cout << "  --occupied-output <file>         Required for both mode\n";
+    std::cout << "  --empty-output <file>            Required for both mode\n";
+}
+
+MeshMode parseMeshMode(const std::string& value) {
+    if (value == "occupied") return MeshMode::Occupied;
+    if (value == "empty") return MeshMode::Empty;
+    if (value == "both") return MeshMode::Both;
+    throw std::runtime_error("Error: Invalid value for --mesh. Expected occupied, empty, or both");
+}
+
+double parseDouble(const std::string& raw, const std::string& optionName) {
+    try {
+        return std::stod(raw);
+    } catch (const std::exception&) {
+        throw std::runtime_error("Error: Invalid numeric value for " + optionName + ": " + raw);
+    }
+}
+
+CliOptions parseArgs(int argc, char* argv[]) {
+    if (argc < 3) {
+        throw std::runtime_error("Error: Missing required arguments");
+    }
+
+    CliOptions options;
+    options.pdbFile = argv[1];
+    options.voxelSize = parseDouble(argv[2], "voxel_size");
+
+    for (int i = 3; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--mesh") {
+            if (++i >= argc) throw std::runtime_error("Error: Missing value for --mesh");
+            options.meshMode = parseMeshMode(argv[i]);
+        } else if (arg == "--padding") {
+            if (++i >= argc) throw std::runtime_error("Error: Missing value for --padding");
+            options.padding = parseDouble(argv[i], "--padding");
+        } else if (arg == "--inflate-factor") {
+            if (++i >= argc) throw std::runtime_error("Error: Missing value for --inflate-factor");
+            options.inflateFactor = parseDouble(argv[i], "--inflate-factor");
+        } else if (arg == "--format") {
+            if (++i >= argc) throw std::runtime_error("Error: Missing value for --format");
+            options.outputFormat = argv[i];
+        } else if (arg == "--output") {
+            if (++i >= argc) throw std::runtime_error("Error: Missing value for --output");
+            options.output = argv[i];
+        } else if (arg == "--occupied-output") {
+            if (++i >= argc) throw std::runtime_error("Error: Missing value for --occupied-output");
+            options.occupiedOutput = argv[i];
+        } else if (arg == "--empty-output") {
+            if (++i >= argc) throw std::runtime_error("Error: Missing value for --empty-output");
+            options.emptyOutput = argv[i];
+        } else {
+            throw std::runtime_error("Error: Unknown option: " + arg);
+        }
+    }
+
+    if (options.voxelSize <= 0.0) {
+        throw std::runtime_error("Error: Voxel size must be positive");
+    }
+    if (options.padding < 0.0) {
+        throw std::runtime_error("Error: Padding cannot be negative");
+    }
+    if (options.inflateFactor <= 0.0) {
+        throw std::runtime_error("Error: Inflate factor must be positive");
+    }
+
+    if (options.outputFormat != "gid" && options.outputFormat != "stl") {
+        throw std::runtime_error("Error: Invalid value for --format. Expected gid or stl");
+    }
+
+    if (options.meshMode == MeshMode::Both) {
+        if (!options.output.empty()) {
+            throw std::runtime_error("Error: --output cannot be used when --mesh is both");
+        }
+        if (options.occupiedOutput.empty() || options.emptyOutput.empty()) {
+            throw std::runtime_error("Error: --occupied-output and --empty-output are required when --mesh is both");
+        }
+        if (options.occupiedOutput == options.emptyOutput) {
+            throw std::runtime_error("Error: Occupied and empty output paths must be different");
+        }
+    } else {
+        if (options.output.empty()) {
+            throw std::runtime_error("Error: --output is required when --mesh is occupied or empty");
+        }
+        if (!options.occupiedOutput.empty() || !options.emptyOutput.empty()) {
+            throw std::runtime_error("Error: --occupied-output and --empty-output are only valid when --mesh is both");
+        }
+    }
+
+    return options;
+}
+
+const char* modeName(MeshMode mode) {
+    switch (mode) {
+        case MeshMode::Occupied: return "occupied";
+        case MeshMode::Empty: return "empty";
+        case MeshMode::Both: return "both";
+    }
+    return "unknown";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    try {
+        CliOptions options = parseArgs(argc, argv);
+
+        std::cout << "BioMesh - Unified Preprocessing Pipeline\n";
+        std::cout << "=======================================\n\n";
+        std::cout << "Configuration:\n";
+        std::cout << "  Mesh mode: " << modeName(options.meshMode) << "\n";
+        std::cout << "  Voxel size: " << options.voxelSize << " Å\n";
+        std::cout << "  Padding: " << options.padding << " Å\n";
+        std::cout << "  Inflate factor: " << options.inflateFactor << "\n";
+        std::cout << "  Format: " << options.outputFormat << "\n\n";
+
+        std::cout << "[1/3] Loading PDB file: " << options.pdbFile << "\n";
+        auto basicAtoms = PDBParser::parsePDBFile(options.pdbFile);
+        std::cout << "      Loaded " << basicAtoms.size() << " atoms\n\n";
+
+        std::cout << "[2/3] Enriching atoms with physical properties\n";
+        AtomBuilder builder(options.inflateFactor);
+        auto enrichedAtoms = builder.buildAtoms(basicAtoms);
+        std::cout << "      Enriched " << enrichedAtoms.size() << " atoms\n\n";
+
+        std::cout << "[3/3] Building voxel grid\n";
+        VoxelGrid voxelGrid(enrichedAtoms, options.voxelSize, options.padding);
+        voxelGrid.printStatistics();
+
+        std::cout << "\nPreprocessing completed successfully.\n";
+        std::cout << "Mesh generation/export is not yet wired in this ticket.\n";
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << "\n\n";
+        printUsage(argv[0]);
+        return 1;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a single entrypoint that centralizes shared preprocessing for occupied/empty mesh workflows as specified in Ticket 2 of the plan. 
- Prepare infrastructure for subsequent tickets that will implement occupied/empty mesh branches and dual-export orchestration.

### Description
- Add `examples/biomesh.cpp` implementing a `MeshMode` enum (`Occupied`, `Empty`, `Both`) and a `CliOptions` struct with CLI parsing and validation aligned to the Ticket 1 contract. 
- Implement argument parsing and validation for `--mesh`, `--padding`, `--inflate-factor`, `--format`, `--output`, `--occupied-output`, and `--empty-output`, with explicit error messages for invalid inputs. 
- Wire shared preprocessing steps: PDB parsing via `PDBParser`, atom enrichment via `AtomBuilder`, voxel grid construction via `VoxelGrid`, and unified logging/statistics output; mesh generation/export is intentionally left for later tickets. 
- Register a new `biomesh` executable target in `CMakeLists.txt` while keeping existing legacy example executables unchanged.

### Testing
- Built the project with `cmake -S . -B build && cmake --build build -j4` and the build completed successfully (GoogleTest not found; tests were not built). 
- Ran preprocessing success case with `./build/biomesh data/test_peptide.pdb 1.5 --mesh both --occupied-output out_occ.msh --empty-output out_emp.msh --padding 2.0 --inflate-factor 1.0 --format gid` and it completed preprocessing successfully (mesh generation/export deferred). 
- Exercised validation failure paths: `./build/biomesh data/test_peptide.pdb 0 --mesh occupied --output x.msh` returned non-zero with `Error: Voxel size must be positive`, and `./build/biomesh data/test_peptide.pdb 1.0 --mesh nope --output x.msh` returned non-zero with `Error: Invalid value for --mesh. Expected occupied, empty, or both`, both behaving as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55a02ff008320b7e5a3b8c7d6a27d)