### PR TITLE
Implement occupied mesh branch in unified `biomesh` executable

### DIFF
--- a/examples/biomesh.cpp
+++ b/examples/biomesh.cpp
@@ -1,8 +1,11 @@
+#include "biomesh/VoxelMeshGenerator.hpp"
+#include "biomesh/MeshExporter.hpp"
 #include "biomesh/PDBParser.hpp"
 #include "biomesh/AtomBuilder.hpp"
 #include "biomesh/VoxelGrid.hpp"
 
 #include <exception>
+#include <iomanip>
 #include <iostream>
 #include <string>
 
@@ -168,9 +171,41 @@ int main(int argc, char* argv[]) {
         VoxelGrid voxelGrid(enrichedAtoms, options.voxelSize, options.padding);
         voxelGrid.printStatistics();
 
-        std::cout << "\nPreprocessing completed successfully.\n";
-        std::cout << "Mesh generation/export is not yet wired in this ticket.\n";
-        return 0;
+        if (options.meshMode == MeshMode::Occupied) {
+            std::cout << "\nGenerating hexahedral mesh from occupied voxels...\n";
+            HexMesh mesh = VoxelMeshGenerator::generateHexMesh(voxelGrid);
+
+            std::cout << "  Generated mesh:\n";
+            std::cout << "    Nodes: " << mesh.getNodeCount() << "\n";
+            std::cout << "    Elements: " << mesh.getElementCount() << "\n";
+
+            int occupiedVoxelCount = voxelGrid.getOccupiedVoxelCount();
+            int theoreticalNodes = occupiedVoxelCount * 8;
+            double efficiency = 0.0;
+            if (theoreticalNodes > 0) {
+                efficiency = (1.0 - static_cast<double>(mesh.getNodeCount()) / theoreticalNodes) * 100.0;
+            }
+            std::cout << "    Node sharing efficiency: " << std::fixed << std::setprecision(1)
+                      << efficiency << "%\n\n";
+
+            if (mesh.getElementCount() > 100000) {
+                std::cout << "WARNING: Large mesh detected (" << mesh.getElementCount()
+                          << " elements). File may be large.\n\n";
+            }
+
+            std::cout << "Exporting to format [" << options.outputFormat << "]: " << options.output << "\n";
+            bool success = MeshExporter::exportMesh(mesh, options.output, options.outputFormat);
+            if (!success) {
+                std::cerr << "  Export failed!\n";
+                return 1;
+            }
+
+            std::cout << "  Export successful!\n";
+            std::cout << "\nMesh file written to: " << options.output << "\n";
+            return 0;
+        }
+
+        throw std::runtime_error("Error: mesh mode not implemented yet in this ticket: " + std::string(modeName(options.meshMode)));
     } catch (const std::exception& e) {
         std::cerr << e.what() << "\n\n";
         printUsage(argv[0]);


### PR DESCRIPTION
### Motivation
- Consolidate occupied-mesh generation into the unified `biomesh` executable so the shared preprocessing pipeline is reused and legacy parity is preserved.
- This change targets Ticket 3 scope only: wire the occupied branch and export behavior while deferring `empty` and `both` modes to later tickets.

### Description
- Implemented the occupied branch in `examples/biomesh.cpp` that calls `VoxelMeshGenerator::generateHexMesh(voxelGrid)` and prints mesh statistics (nodes/elements) and node-sharing efficiency.
- Added large-mesh warning logic and export wiring using `MeshExporter::exportMesh(...)` driven by `--format` and `--output`.
- Retained the shared preprocessing steps (PDB parse, `AtomBuilder`, `VoxelGrid`) and added a clear fail-fast error for unimplemented modes.
- Added necessary includes and formatting (`<iomanip>`) to support the reporting output.

### Testing
- Built the project with `cmake -S . -B build && cmake --build build -j4` and the build completed successfully.
- Performed an automated parity check between the legacy `occupied_voxel_to_gid` and the new `biomesh --mesh occupied` using `data/test_peptide.pdb`, and both reported `Nodes: 361` and `Elements: 169`.
- Note: repository unit tests were not built during the CMake configure step because GoogleTest was not found (CMake issued a warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55c783cf483208345062a702b36e9)