### PR TITLE
Implement Ticket 4: add empty-mesh branch to unified `biomesh` executable

### DIFF
--- a/examples/biomesh.cpp
+++ b/examples/biomesh.cpp
@@ -1,4 +1,5 @@
 #include "biomesh/VoxelMeshGenerator.hpp"
+#include "biomesh/EmptyVoxelMeshGenerator.hpp"
 #include "biomesh/MeshExporter.hpp"
 #include "biomesh/PDBParser.hpp"
 #include "biomesh/AtomBuilder.hpp"
@@ -181,6 +182,40 @@ int main(int argc, char* argv[]) {
 
             int occupiedVoxelCount = voxelGrid.getOccupiedVoxelCount();
             int theoreticalNodes = occupiedVoxelCount * 8;
+            double efficiency = 0.0;
+            if (theoreticalNodes > 0) {
+                efficiency = (1.0 - static_cast<double>(mesh.getNodeCount()) / theoreticalNodes) * 100.0;
+            }
+            std::cout << "    Node sharing efficiency: " << std::fixed << std::setprecision(1)
+                      << efficiency << "%\n\n";
+
+            if (mesh.getElementCount() > 100000) {
+                std::cout << "WARNING: Large mesh detected (" << mesh.getElementCount()
+                          << " elements). File may be large.\n\n";
+            }
+
+            std::cout << "Exporting to format [" << options.outputFormat << "]: " << options.output << "\n";
+            bool success = MeshExporter::exportMesh(mesh, options.output, options.outputFormat);
+            if (!success) {
+                std::cerr << "  Export failed!\n";
+                return 1;
+            }
+
+            std::cout << "  Export successful!\n";
+            std::cout << "\nMesh file written to: " << options.output << "\n";
+            return 0;
+        }
+
+        if (options.meshMode == MeshMode::Empty) {
+            std::cout << "\nGenerating hexahedral mesh from empty voxels...\n";
+            HexMesh mesh = EmptyVoxelMeshGenerator::generateHexMesh(voxelGrid);
+
+            std::cout << "  Generated mesh:\n";
+            std::cout << "    Nodes: " << mesh.getNodeCount() << "\n";
+            std::cout << "    Elements: " << mesh.getElementCount() << "\n";
+
+            int emptyVoxelCount = voxelGrid.getEmptyVoxelCount();
+            int theoreticalNodes = emptyVoxelCount * 8;
             double efficiency = 0.0;
             if (theoreticalNodes > 0) {
                 efficiency = (1.0 - static_cast<double>(mesh.getNodeCount()) / theoreticalNodes) * 100.0;


### PR DESCRIPTION
### Motivation
- Provide empty-voxel mesh generation in the unified `biomesh` executable to complete Ticket 4 of the unified pipeline plan. 
- Reuse the shared preprocessing implemented earlier so empty-mesh generation reuses PDB parsing, atom enrichment, and voxel-grid construction.

### Description
- Added `#include "biomesh/EmptyVoxelMeshGenerator.hpp"` and implemented the `--mesh empty` branch in `examples/biomesh.cpp` to generate empty-voxel hexahedral meshes. 
- The new branch calls `EmptyVoxelMeshGenerator::generateHexMesh(voxelGrid)`, prints node/element counts, computes node-sharing efficiency, preserves the large-mesh warning, and exports via `MeshExporter::exportMesh`. 
- Preserved existing `--mesh occupied` behavior and left `--mesh both` intentionally unimplemented for later tickets.

### Testing
- Built the project successfully with `cmake -S . -B build && cmake --build build -j4` (passed). 
- Verified parity with the legacy tool by running `empty_voxel_to_gid` and `biomesh --mesh empty` on `data/test_peptide.pdb` and confirming matching `Nodes` and `Elements` output (matched). 
- Verified export formats by creating an STL with `./build/biomesh ... --format stl` and confirming the output file is non-empty (`test -s` returned OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55dc608388320bc3c2db483e6fdd4)