### PR TITLE
Ticket 6: Make `biomesh` canonical target and add legacy compatibility wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,17 +44,13 @@ target_link_libraries(biomesh_example biomesh_lib)
 add_executable(voxel_demo examples/voxel_demo.cpp)
 target_link_libraries(voxel_demo biomesh_lib)
 
-# Create executable for empty voxel to GiD export
-add_executable(empty_voxel_to_gid examples/empty_voxel_to_gid.cpp)
-target_link_libraries(empty_voxel_to_gid biomesh_lib)
-
-# Create executable for occupied voxel to GiD export
-add_executable(occupied_voxel_to_gid examples/occupied_voxel_to_gid.cpp)
-target_link_libraries(occupied_voxel_to_gid biomesh_lib)
-
-# Create unified biomesh executable (shared preprocessing skeleton)
+# Create unified biomesh executable
 add_executable(biomesh examples/biomesh.cpp)
 target_link_libraries(biomesh biomesh_lib)
+
+# Legacy compatibility wrappers (deprecated): forward to biomesh
+add_executable(empty_voxel_to_gid examples/empty_voxel_to_gid_wrapper.cpp)
+add_executable(occupied_voxel_to_gid examples/occupied_voxel_to_gid_wrapper.cpp)
 
 # Create executable for filter demonstration
 add_executable(filter_demo examples/filter_demo.cpp)

--- a/docs/biomesh_cli_contract.md
+++ b/docs/biomesh_cli_contract.md
@@ -162,3 +162,14 @@ biomesh protein.pdb 1.0 \
   --format gid
 ```
 
+
+
+---
+
+## 6) Ticket 6 migration decision (implemented)
+
+Migration path selected: **keep legacy executable names temporarily as compatibility wrappers**.
+
+- `biomesh` is the canonical unified executable target in CMake.
+- `occupied_voxel_to_gid` and `empty_voxel_to_gid` remain available as deprecated wrappers that forward legacy positional arguments to `biomesh` with `--mesh occupied` / `--mesh empty`.
+- This preserves existing scripts while centralizing runtime behavior in the unified pipeline.

--- a/examples/empty_voxel_to_gid_wrapper.cpp
+++ b/examples/empty_voxel_to_gid_wrapper.cpp
@@ -1,0 +1,49 @@
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#include <process.h>
+#define EXECVP _execvp
+#else
+#include <unistd.h>
+#define EXECVP execvp
+#endif
+
+int main(int argc, char* argv[]) {
+    if (argc < 4) {
+        std::cerr << "Usage: " << argv[0]
+                  << " <pdb_file> <voxel_size> <output_file> [padding] [inflate_factor] [format]\n";
+        return 1;
+    }
+
+    std::string padding = (argc > 4) ? argv[4] : "2.0";
+    std::string inflateFactor = (argc > 5) ? argv[5] : "1.0";
+    std::string format = (argc > 6) ? argv[6] : "gid";
+
+    std::filesystem::path biomeshPath = std::filesystem::path(argv[0]).parent_path() / "biomesh";
+
+    std::vector<std::string> args = {
+        biomeshPath.string(),
+        argv[1],
+        argv[2],
+        "--mesh", "empty",
+        "--output", argv[3],
+        "--padding", padding,
+        "--inflate-factor", inflateFactor,
+        "--format", format
+    };
+
+    std::vector<char*> execArgs;
+    execArgs.reserve(args.size() + 1);
+    for (auto& arg : args) {
+        execArgs.push_back(const_cast<char*>(arg.c_str()));
+    }
+    execArgs.push_back(nullptr);
+
+    std::cerr << "[compat] empty_voxel_to_gid is deprecated; forwarding to biomesh.\n";
+    int result = EXECVP(execArgs[0], execArgs.data());
+    std::cerr << "Error: Failed to execute compat biomesh wrapper at: " << biomeshPath << "\n";
+    return (result == -1) ? 1 : result;
+}

--- a/examples/occupied_voxel_to_gid_wrapper.cpp
+++ b/examples/occupied_voxel_to_gid_wrapper.cpp
@@ -1,0 +1,49 @@
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#include <process.h>
+#define EXECVP _execvp
+#else
+#include <unistd.h>
+#define EXECVP execvp
+#endif
+
+int main(int argc, char* argv[]) {
+    if (argc < 4) {
+        std::cerr << "Usage: " << argv[0]
+                  << " <pdb_file> <voxel_size> <output_file> [padding] [inflate_factor] [format]\n";
+        return 1;
+    }
+
+    std::string padding = (argc > 4) ? argv[4] : "2.0";
+    std::string inflateFactor = (argc > 5) ? argv[5] : "1.0";
+    std::string format = (argc > 6) ? argv[6] : "gid";
+
+    std::filesystem::path biomeshPath = std::filesystem::path(argv[0]).parent_path() / "biomesh";
+
+    std::vector<std::string> args = {
+        biomeshPath.string(),
+        argv[1],
+        argv[2],
+        "--mesh", "occupied",
+        "--output", argv[3],
+        "--padding", padding,
+        "--inflate-factor", inflateFactor,
+        "--format", format
+    };
+
+    std::vector<char*> execArgs;
+    execArgs.reserve(args.size() + 1);
+    for (auto& arg : args) {
+        execArgs.push_back(const_cast<char*>(arg.c_str()));
+    }
+    execArgs.push_back(nullptr);
+
+    std::cerr << "[compat] occupied_voxel_to_gid is deprecated; forwarding to biomesh.\n";
+    int result = EXECVP(execArgs[0], execArgs.data());
+    std::cerr << "Error: Failed to execute compat biomesh wrapper at: " << biomeshPath << "\n";
+    return (result == -1) ? 1 : result;
+}


### PR DESCRIPTION
### Motivation
- Implement Ticket 6 migration by consolidating runtime into the unified `biomesh` executable while preserving legacy command names for compatibility. 
- Provide a clear, reversible migration path that avoids duplicating logic and preserves existing user scripts. 

### Description
- Updated `CMakeLists.txt` to make `biomesh` the canonical executable and to register deprecated wrapper targets `empty_voxel_to_gid` and `occupied_voxel_to_gid` that forward to `biomesh`. 
- Added `examples/occupied_voxel_to_gid_wrapper.cpp` which maps legacy positional arguments to `biomesh --mesh occupied` with compatibility defaults and prints a deprecation notice. 
- Added `examples/empty_voxel_to_gid_wrapper.cpp` which maps legacy positional arguments to `biomesh --mesh empty` with compatibility defaults and prints a deprecation notice. 
- Appended the Ticket 6 migration decision to `docs/biomesh_cli_contract.md` documenting the chosen compatibility-wrappers approach. 

### Testing
- Ran `cmake -S . -B build` which configured successfully. 
- Ran `cmake --build build -j4` which compiled `biomesh` and the legacy wrapper targets successfully. 
- Build emitted `GoogleTest not found. Tests will not be built.` so unit tests were not built in this environment (dependency missing), and no test failures were observed from the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56249e6488320bd44438f0bf85e71)