### PR TITLE
Ticket 7: migrate docs to unified biomesh CLI and add no-deps smoke test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,12 @@ target_link_libraries(filter_workflow_example biomesh_lib)
 # Enable testing
 enable_testing()
 
+# Minimal no-deps smoke test target (always available, including constrained CI)
+add_executable(biomesh_smoke_test tests/smoke_no_deps.cpp)
+target_link_libraries(biomesh_smoke_test biomesh_lib)
+target_compile_definitions(biomesh_smoke_test PRIVATE BIOMESH_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+add_test(NAME SmokeNoDeps COMMAND biomesh_smoke_test)
+
 # Find GoogleTest
 find_package(GTest QUIET)
 if(GTest_FOUND)

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ cmake ..
 make -j4
 
 # Verify
-./occupied_voxel_to_gid
-./empty_voxel_to_gid
+./biomesh --help
+ctest --output-on-failure
 ```
 
 ### Basic Usage
@@ -53,12 +53,16 @@ make -j4
 # Return to project root
 cd ..
 
-# Generate both occupied and empty meshes
-./biomesh. sh protein.pdb
+# Generate occupied mesh only
+./build/biomesh protein.pdb 1.0 --mesh occupied --output occupied_mesh.msh
 
-# Output:
-#   mesh_occupied.msh  (molecule mesh)
-#   mesh_empty.msh     (fluid domain mesh)
+# Generate empty mesh only
+./build/biomesh protein.pdb 1.0 --mesh empty --output empty_mesh.msh
+
+# Generate both meshes in one preprocessing pass
+./build/biomesh protein.pdb 1.0 --mesh both \
+  --occupied-output mesh_occupied.msh \
+  --empty-output mesh_empty.msh
 ```
 
 ### High-Resolution Example
@@ -74,6 +78,37 @@ wget https://files.rcsb.org/download/1CRN.pdb
 #   crambin_highres_occupied.msh
 #   crambin_highres_empty.msh
 ```
+
+---
+
+## Unified CLI Migration (Ticket 7)
+
+`biomesh` is now the canonical executable for occupied, empty, and combined workflows.
+
+### Legacy command replacements
+
+```bash
+# Legacy occupied
+./occupied_voxel_to_gid protein.pdb 1.0 occupied.msh 2.0 1.0 gid
+# Unified equivalent
+./biomesh protein.pdb 1.0 --mesh occupied --output occupied.msh --padding 2.0 --inflate-factor 1.0 --format gid
+
+# Legacy empty
+./empty_voxel_to_gid protein.pdb 1.0 empty.stl 2.0 1.0 stl
+# Unified equivalent
+./biomesh protein.pdb 1.0 --mesh empty --output empty.stl --padding 2.0 --inflate-factor 1.0 --format stl
+```
+
+### Output argument rules
+
+- `--mesh occupied|empty` requires `--output` and rejects `--occupied-output/--empty-output`.
+- `--mesh both` requires both `--occupied-output` and `--empty-output`, and rejects `--output`.
+- In `both` mode, occupied and empty output paths must be different.
+
+### Minimal CI test coverage
+
+- `SmokeNoDeps` is a no-dependency CTest target that validates parser + voxelization + occupied/empty meshing in constrained environments.
+- Full regression coverage remains under `biomesh_tests` when GoogleTest is available.
 
 ---
 

--- a/docs/unified_executable_plan.md
+++ b/docs/unified_executable_plan.md
@@ -141,9 +141,9 @@ while centralizing shared logic into one maintainable pipeline.
 - Updated user-facing docs and examples.
 
 ### Acceptance Criteria
-- [ ] README no longer instructs new users to run two separate mesh executables.
-- [ ] At least one example each for occupied-only, empty-only, and both-mode is present.
-- [ ] Error/validation expectations are documented for common misuse cases.
+- [x] README no longer instructs new users to run two separate mesh executables.
+- [x] At least one example each for occupied-only, empty-only, and both-mode is present.
+- [x] Error/validation expectations are documented for common misuse cases.
 
 ---
 
@@ -185,3 +185,7 @@ while centralizing shared logic into one maintainable pipeline.
 - Dual export is deterministic with explicit output controls.
 - Legacy executable transition is complete and documented.
 - Build and tests are green, with parity evidence captured.
+
+
+### Ticket 7 addendum for constrained CI
+- Add a minimal, no-dependency `SmokeNoDeps` CTest target so core mesh generation is validated even when GoogleTest is unavailable.

--- a/tests/smoke_no_deps.cpp
+++ b/tests/smoke_no_deps.cpp
@@ -1,0 +1,48 @@
+#include "biomesh/AtomBuilder.hpp"
+#include "biomesh/EmptyVoxelMeshGenerator.hpp"
+#include "biomesh/PDBParser.hpp"
+#include "biomesh/VoxelGrid.hpp"
+#include "biomesh/VoxelMeshGenerator.hpp"
+
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+
+int main() {
+    try {
+        const std::filesystem::path pdbPath = std::filesystem::path(BIOMESH_SOURCE_DIR) / "data" / "test_peptide.pdb";
+        if (!std::filesystem::exists(pdbPath)) {
+            std::cerr << "Smoke test fixture missing: " << pdbPath << "\n";
+            return 1;
+        }
+
+        auto basicAtoms = biomesh::PDBParser::parsePDBFile(pdbPath.string());
+        if (basicAtoms.empty()) {
+            std::cerr << "Smoke test failed: parser returned no atoms\n";
+            return 1;
+        }
+
+        biomesh::AtomBuilder builder(1.0);
+        auto enrichedAtoms = builder.buildAtoms(basicAtoms);
+        biomesh::VoxelGrid voxelGrid(enrichedAtoms, 1.0, 2.0);
+
+        auto occupiedMesh = biomesh::VoxelMeshGenerator::generateHexMesh(voxelGrid);
+        auto emptyMesh = biomesh::EmptyVoxelMeshGenerator::generateHexMesh(voxelGrid);
+
+        if (occupiedMesh.getNodeCount() == 0 || occupiedMesh.getElementCount() == 0) {
+            std::cerr << "Smoke test failed: occupied mesh is empty\n";
+            return 1;
+        }
+        if (emptyMesh.getNodeCount() == 0 || emptyMesh.getElementCount() == 0) {
+            std::cerr << "Smoke test failed: empty mesh is empty\n";
+            return 1;
+        }
+
+        std::cout << "Smoke test passed: occupied=" << occupiedMesh.getElementCount()
+                  << " empty=" << emptyMesh.getElementCount() << "\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "Smoke test exception: " << ex.what() << "\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
### Motivation
- Consolidate user-facing instructions to the new unified `biomesh` CLI per Ticket 7 so users and CI no longer rely on two legacy executables. 
- Provide minimal, dependency-free CI coverage for core preprocessing+mesh generation so constrained environments (containers, minimal runners) exercise critical code paths even when GoogleTest is unavailable. 

### Description
- Added a minimal no-dependency smoke test `tests/smoke_no_deps.cpp` that exercises PDB parsing → atom enrichment → voxelization → occupied and empty mesh generation and fails on empty outputs. 
- Updated `CMakeLists.txt` to always build and register a CTest target `SmokeNoDeps` (`biomesh_smoke_test`), and added a `target_compile_definitions` entry so the smoke test can locate repository fixtures via `BIOMESH_SOURCE_DIR`. 
- Updated `README.md` to make `biomesh` the canonical executable and added explicit examples for `--mesh occupied`, `--mesh empty`, and `--mesh both`, plus a migration section showing legacy → unified command mappings and output-argument rules. 
- Updated `docs/unified_executable_plan.md` to mark the Ticket 7 acceptance criteria as complete and added a constrained-CI addendum documenting the `SmokeNoDeps` target. 

### Testing
- Ran `cmake -S . -B build` and `cmake --build build -j4`, which configured and built all targets including `biomesh_smoke_test`. (Succeeded.)
- Executed `ctest --test-dir build --output-on-failure`; an initial run reported the smoke test fixture missing until the smoke test was wired to `BIOMESH_SOURCE_DIR`, after which rebuild and `ctest` succeeded with `SmokeNoDeps` passing. (Final: `SmokeNoDeps` passed.)
- Verified existing GoogleTest behavior is preserved: `find_package(GTest)` remains in CMake and the GTest-based `biomesh_tests` target is only created when GTest is found; in this environment GTest was not available so the full test suite was not built. (Observed and preserved.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f567d03008832080df5a6f30ef754a)