### PR TITLE
docs: Add OpenMP build instructions and micromamba troubleshooting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,80 @@ git branch
 bash -lc 'mkdir -p build && cd build && cmake .. && cmake --build . -j'
 ```
 
+### Build with OpenMP multithreading
+
+OpenMP is enabled automatically when CMake can find an OpenMP-capable compiler/runtime.
+
+```bash
+# from repo root
+mkdir -p build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build . -j
+```
+
+During `cmake ..`, look for one of these status lines:
+
+- `OpenMP found - parallel mesh generation enabled`
+- `OpenMP not found - mesh generation will run serially`
+
+If OpenMP is not found, install/update your compiler toolchain and OpenMP runtime, then re-run CMake in a clean build directory.
+
+#### Installing OpenMP in a micromamba environment
+
+If you are building inside micromamba, install compiler + OpenMP runtime packages from `conda-forge` in your active environment:
+
+```bash
+# create/activate env (example)
+micromamba create -n biomesh -c conda-forge cmake ninja cxx-compiler
+micromamba activate biomesh
+
+# Linux: GNU OpenMP runtime
+micromamba install -n biomesh -c conda-forge libgomp
+
+# macOS (clang): LLVM OpenMP runtime
+micromamba install -n biomesh -c conda-forge llvm-openmp
+```
+
+Then configure/build from a fresh build directory:
+
+```bash
+rm -rf build
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build . -j
+```
+
+Re-check CMake output for `OpenMP found - parallel mesh generation enabled`.
+
+##### Linux/macOS troubleshooting (micromamba)
+
+If CMake still cannot detect OpenMP in micromamba, point CMake to the active environment and explicitly choose compilers from that environment:
+
+```bash
+# make sure env is active first
+micromamba activate biomesh
+
+# Linux/macOS: use env prefix + env compilers
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+  -DCMAKE_C_COMPILER="$CONDA_PREFIX/bin/x86_64-conda-linux-gnu-cc" \
+  -DCMAKE_CXX_COMPILER="$CONDA_PREFIX/bin/x86_64-conda-linux-gnu-c++"
+```
+
+On macOS with clang-based toolchains, this variant is often sufficient:
+
+```bash
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++
+```
+
+Tip: if compiler paths differ in your environment, inspect `$CONDA_PREFIX/bin` and substitute the exact compiler executable names.
+
 ### Run unified executable
 
 ```bash


### PR DESCRIPTION
### Motivation
- Clarify how OpenMP support is detected and enabled during CMake configuration so users can build with multithreading.
- Provide step-by-step instructions for installing OpenMP runtimes in micromamba/conda-forge environments to simplify reproducible builds.
- Add troubleshooting guidance and explicit `cmake` variants for environments where compilers from the active environment must be pointed at explicitly.

### Description
- Added a new "Build with OpenMP multithreading" section to `README.md` that documents detection messages `OpenMP found - parallel mesh generation enabled` and `OpenMP not found - mesh generation will run serially`.
- Included example build commands using `cmake ..`, `cmake --build . -j`, and a recommended `-DCMAKE_BUILD_TYPE=Release` workflow.
- Added detailed micromamba/conda-forge installation steps for `libgomp` (Linux) and `llvm-openmp` (macOS) and example environment commands like `micromamba create -n biomesh -c conda-forge cmake ninja cxx-compiler` and `micromamba install -n biomesh -c conda-forge libgomp`.
- Added troubleshooting `cmake` invocations that set `-DCMAKE_PREFIX_PATH`, `-DCMAKE_C_COMPILER`, and `-DCMAKE_CXX_COMPILER` to use compilers from the active environment, and a command to recreate the build directory `rm -rf build`.

### Testing
- No source code was changed; documentation-only updates were made to `README.md` and therefore no code-level changes required validation.
- Ran the project's automated test suite with `ctest --output-on-failure` to confirm existing tests still pass, and the test run completed successfully.
- Verified that the README examples are syntactically correct and reference the existing build workflow without altering build scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58b21052c8320b10f45ad8e3cf075)