### PR TITLE
docs: Add OpenMP build instructions, runtime guidance, and micromamba troubleshooting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,107 @@ git branch
 bash -lc 'mkdir -p build && cd build && cmake .. && cmake --build . -j'
 ```
 
+### Build with OpenMP multithreading
+
+OpenMP is enabled automatically when CMake can find an OpenMP-capable compiler/runtime.
+
+```bash
+# from repo root
+mkdir -p build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build . -j
+```
+
+During `cmake ..`, look for one of these status lines:
+
+- `OpenMP found - parallel mesh generation enabled`
+- `OpenMP not found - mesh generation will run serially`
+
+If OpenMP is not found, install/update your compiler toolchain and OpenMP runtime, then re-run CMake in a clean build directory.
+
+#### Installing OpenMP in a micromamba environment
+
+If you are building inside micromamba, install compiler + OpenMP runtime packages from `conda-forge` in your active environment:
+
+```bash
+# create/activate env (example)
+micromamba create -n biomesh -c conda-forge cmake ninja cxx-compiler
+micromamba activate biomesh
+
+# Linux: GNU OpenMP runtime
+micromamba install -n biomesh -c conda-forge libgomp
+
+# macOS (clang): LLVM OpenMP runtime
+micromamba install -n biomesh -c conda-forge llvm-openmp
+```
+
+Then configure/build from a fresh build directory:
+
+```bash
+rm -rf build
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build . -j
+```
+
+Re-check CMake output for `OpenMP found - parallel mesh generation enabled`.
+
+#### Runtime thread count (OpenMP)
+
+Yes — OpenMP-enabled builds may still run with one thread unless the runtime decides otherwise.
+Set the thread count explicitly before running `biomesh`:
+
+```bash
+# use all visible cores
+export OMP_NUM_THREADS=$(nproc)      # Linux
+# export OMP_NUM_THREADS=$(sysctl -n hw.ncpu)   # macOS
+
+# or set a fixed count
+export OMP_NUM_THREADS=8
+
+./biomesh ../data/test_peptide.pdb 1.0 --mesh occupied --output occupied.msh
+```
+
+Useful diagnostics:
+
+```bash
+# bind OpenMP threads and print runtime settings
+export OMP_PROC_BIND=true
+export OMP_PLACES=cores
+export OMP_DISPLAY_ENV=VERBOSE
+```
+
+Note: in BioMesh, OpenMP currently parallelizes voxel corner-node generation loops; other stages remain serial, so speedup may be limited for small inputs.
+
+##### Linux/macOS troubleshooting (micromamba)
+
+If CMake still cannot detect OpenMP in micromamba, point CMake to the active environment and explicitly choose compilers from that environment:
+
+```bash
+# make sure env is active first
+micromamba activate biomesh
+
+# Linux/macOS: use env prefix + env compilers
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+  -DCMAKE_C_COMPILER="$CONDA_PREFIX/bin/x86_64-conda-linux-gnu-cc" \
+  -DCMAKE_CXX_COMPILER="$CONDA_PREFIX/bin/x86_64-conda-linux-gnu-c++"
+```
+
+On macOS with clang-based toolchains, this variant is often sufficient:
+
+```bash
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++
+```
+
+Tip: if compiler paths differ in your environment, inspect `$CONDA_PREFIX/bin` and substitute the exact compiler executable names.
+
 ### Run unified executable
 
 ```bash


### PR DESCRIPTION
### Motivation
- Provide clear instructions for building BioMesh with OpenMP-enabled multithreading when an OpenMP-capable compiler/runtime is available.
- Help users configure runtime thread counts and diagnostic environment variables for reproducible parallel runs.
- Document platform-specific steps for installing OpenMP runtimes inside `micromamba` environments and offer troubleshooting steps when CMake does not detect OpenMP.

### Description
- Extended `README.md` with a new "Build with OpenMP multithreading" section that explains automatic OpenMP detection by CMake and shows expected status messages from configuration.
- Added step-by-step `cmake`/build examples and explicit commands to set `OMP_NUM_THREADS` and run `biomesh` with a chosen thread count.
- Included `micromamba` instructions for installing `libgomp` (Linux) and `llvm-openmp` (macOS), plus example `cmake` invocations that set `CMAKE_PREFIX_PATH` and explicit compilers to help CMake find OpenMP in the active environment.
- Added runtime diagnostics (`OMP_PROC_BIND`, `OMP_PLACES`, `OMP_DISPLAY_ENV`) and a note that OpenMP currently parallelizes voxel corner-node generation only, so speedup may be limited for small inputs.

### Testing
- Documentation-only change; no automated tests were required or run as part of this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58b21052c8320b10f45ad8e3cf075)